### PR TITLE
jjvein@ Date:2016-03-28(16:20:20) commit Branch:fix-test Tag:"assert"

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -14,7 +14,7 @@ describe('test', function(){
     it('throw' , ()=>{
         var obj2 = undefined
         assert.throws(
-            objectKeys(obj2),
+            objectKeys.bind(null, obj2),
             Error
         )
     })


### PR DESCRIPTION
由于assert.throws()接收对象， 所以这里使用`objectKeys.bind(null, obj2)`完成修改。
